### PR TITLE
Remove Graph Tools

### DIFF
--- a/python-graph-analysis/dockerfile/Dockerfile
+++ b/python-graph-analysis/dockerfile/Dockerfile
@@ -4,13 +4,6 @@ LABEL maintainer "Kaoru Yamaoka <kaoru.yamaoka@gmail.com>"
 #install jupyter lab
 RUN pip install --upgrade pip && pip install jupyterlab
 
-# install graph-tool
-RUN echo "deb [ arch=amd64 ] https://downloads.skewed.de/apt buster main" >> /etc/apt/sources.list \
-&& apt-key adv --keyserver keys.openpgp.org --recv-key 612DEFB798507F25 \
-&& apt-get update \
-&& apt-get install -y python3-graph-tool \
-&& rm -rf /var/lib/apt/lists/*
-
 # install libspatialindex (dependency for osmnx)
 RUN apt-get update && apt-get install -y libspatialindex-dev && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Switch to `igraph` from `graph-tool`. One can use dedicated docker image for `graph-tool` when necessary.